### PR TITLE
fix for compiler error on ARM

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -18,6 +18,7 @@
  *                                                                   USA
  */
 
+#include <inttypes.h>
 #include "dtc.h"
 
 #ifdef TRACE_CHECKS
@@ -873,7 +874,7 @@ static void check_simple_bus_reg(struct check *c, struct dt_info *dti, struct no
 	while (size--)
 		reg = (reg << 32) | fdt32_to_cpu(*(cells++));
 
-	snprintf(unit_addr, sizeof(unit_addr), "%zx", reg);
+	snprintf(unit_addr, sizeof(unit_addr), "%" PRIx64, reg);
 	if (!streq(unitname, unit_addr))
 		FAIL(c, dti, "Node %s simple-bus unit address format error, expected \"%s\"",
 		     node->fullpath, unit_addr);


### PR DESCRIPTION
I got the next error, the fix seems trivial and obvious.

```
checks.c: In function ‘check_simple_bus_reg’:
checks.c:876:41: error: format ‘%zx’ expects argument of type ‘size_t’, but argument 4 has type ‘uint64_t {aka long long unsigned int}’ [-Werror=format=]
  snprintf(unit_addr, sizeof(unit_addr), "%zx", reg);
                                         ^
checks.c:876:41: error: format ‘%zx’ expects argument of type ‘size_t’, but argument 4 has type ‘uint64_t {aka long long unsigned int}’ [-Werror=format=]
cc1: all warnings being treated as errors
Makefile:310: recipe for target 'checks.o' failed
make: *** [checks.o] Error 1
```

I would also be glad if a tag was created, or otherwise is there a stable branch with overlay support?